### PR TITLE
PCHR-3071: Update Role names

### DIFF
--- a/app/config/hr17/install.sh
+++ b/app/config/hr17/install.sh
@@ -6,13 +6,13 @@
 # Creates the default CiviHR users
 function create_default_users() {
   drush -y user-create --password="civihr_staff" --mail="civihr_staff@compucorp.co.uk" "civihr_staff"
-  drush -y user-add-role civihr_staff "civihr_staff"
+  drush -y user-add-role Staff "civihr_staff"
 
   drush -y user-create --password="civihr_manager" --mail="civihr_manager@compucorp.co.uk" "civihr_manager"
-  drush -y user-add-role civihr_manager "civihr_manager"
+  drush -y user-add-role Manager "civihr_manager"
 
   drush -y user-create --password="civihr_admin" --mail="civihr_admin@compucorp.co.uk" "civihr_admin"
-  drush -y user-add-role civihr_admin "civihr_admin"
+  drush -y user-add-role "HR Admin" "civihr_admin"
 }
 
 ##


### PR DESCRIPTION
## Overview
This PR updates the role names to the new names in the install files for installation type `hr16` and `hr17` after the role names were changed [here](https://github.com/compucorp/civihr-employee-portal/pull/435)

