### PR TITLE
PCHR-3854: Add google_tag and datalayer modules

### DIFF
--- a/app/config/hr17/drush.make.tmpl
+++ b/app/config/hr17/drush.make.tmpl
@@ -222,6 +222,12 @@ projects[menu_attributes][version] = 1.0
 projects[roles_for_menu][subdir] = civihr-contrib-required
 projects[roles_for_menu][version] = 1.1
 
+projects[google_tag][subdir] = civihr-contrib-required
+projects[google_tag][version] = 1.3
+
+projects[datalayer][subdir] = civihr-contrib-required
+projects[datalayer][version] = 1.1
+
 ; ****************************************
 ; Compucorp custom drupal modules
 ; ****************************************


### PR DESCRIPTION
Adding the [google_tag](https://www.drupal.org/project/google_tag) and [dalayer](https://www.drupal.org/project/datalayer) modules to the CiviHR 1.7 build